### PR TITLE
fix(pyproject): point PyPI URLs at the actual SDK repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ dependencies = [
 test = ["pytest-asyncio>=0.24"]
 
 [project.urls]
-Homepage = "https://github.com/hongmingw/molecule-monorepo"
-Repository = "https://github.com/hongmingw/molecule-monorepo"
-Documentation = "https://github.com/hongmingw/molecule-monorepo/tree/main/sdk/python"
+Homepage = "https://github.com/Molecule-AI/molecule-sdk-python"
+Repository = "https://github.com/Molecule-AI/molecule-sdk-python"
+Documentation = "https://github.com/Molecule-AI/molecule-sdk-python#readme"
 
 [tool.setuptools.packages.find]
 include = ["molecule_plugin*", "molecule_agent*"]


### PR DESCRIPTION
## Summary

PyPI page for `molecule-ai-sdk` currently shows three broken links pointing at `github.com/hongmingw/molecule-monorepo` — a personal-account URL with the wrong repo name. Real location is this repo, `Molecule-AI/molecule-sdk-python`.

## Changes

| Field | Old | New |
|---|---|---|
| Homepage | `github.com/hongmingw/molecule-monorepo` | `github.com/Molecule-AI/molecule-sdk-python` |
| Repository | `github.com/hongmingw/molecule-monorepo` | `github.com/Molecule-AI/molecule-sdk-python` |
| Documentation | `github.com/hongmingw/molecule-monorepo/tree/main/sdk/python` | `github.com/Molecule-AI/molecule-sdk-python#readme` |

## Notes

- Scanned the rest of the org for the same `hongmingw/molecule-monorepo` pattern in `pyproject.toml` files — only this package has it. No fix needed elsewhere.
- URLs surface in PyPI's package page and in `pip show molecule-ai-sdk` output. They're metadata only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)